### PR TITLE
fix: refactoring by passing the VotingCtx provider into the withProviders function.

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -11,15 +11,13 @@ import type { AppProps } from 'next/app';
 function MyApp({ Component, pageProps }: AppProps) {
   return withProviders(
     <ChakraProvider theme={theme}>
-      <VotingCtxProvider>
-        <CSSReset />
-        <Component {...pageProps} />
-      </VotingCtxProvider>
+      <CSSReset />
+      <Component {...pageProps} />
     </ChakraProvider>,
     providers,
   );
 }
 
-const providers = [ConfigProvider];
+const providers = [ConfigProvider, VotingCtxProvider];
 
 export default MyApp;


### PR DESCRIPTION
# Description

Added VontingCtx the function withProviders.

## Changes

## Notes

- The ChakraProvider provider was not possible to add as a provider in the parameter for the function withProviders because ChakraProvider contains a theme property 

## Board issue


- Closes #29
